### PR TITLE
Undefined name: import torch for lines 22, 24, 25

### DIFF
--- a/utils/misc.py
+++ b/utils/misc.py
@@ -9,6 +9,7 @@ import sys
 import time
 import math
 
+import torch
 import torch.nn as nn
 import torch.nn.init as init
 from torch.autograd import Variable


### PR DESCRIPTION
__torch__ is used but is never imported or defined.

flake8 testing of https://github.com/XingangPan/IBN-Net on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./imagenet.py:250:63: E999 SyntaxError: invalid syntax
            inputs, targets = inputs.cuda(), targets.cuda(async=True)
                                                              ^
./utils/misc.py:21:32: F821 undefined name 'torch'
    dataloader = trainloader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=True, num_workers=2)
                               ^
./utils/misc.py:23:12: F821 undefined name 'torch'
    mean = torch.zeros(3)
           ^
./utils/misc.py:24:11: F821 undefined name 'torch'
    std = torch.zeros(3)
          ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'torch'
4
```